### PR TITLE
Hide signup link on past events

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,10 @@
 future: true
+
+defaults:
+  -
+    scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "event"
+

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -8,10 +8,19 @@ layout: page
 
     <p>Lieu : <a href="{{ page.address-link }}">{{ page.address }}</a></p>
 
+    {% capture nowunix %}{{'today' | date: '%Y-%m-%d'}}{% endcapture %}
+    {% capture posttime %}{{page.date | date: '%Y-%m-%d'}}{% endcapture %}
+
+    {% if nowunix <= posttime and page.meetup-event-id %}
     {% include event-signup.html %}
+    {% else %}
+    <p id="no-future-event">Il n'est pas possible de s'inscrire pour cet évènement.</p>
+    {% endif %}
 
     {{ content }}
 
+    {% if nowunix <= posttime and page.meetup-event-id %}
     {% include event-signup.html %}
+    {% endif %}
 
 </div>

--- a/_posts/2019-10-29-2-ans-prod-hadoop.md
+++ b/_posts/2019-10-29-2-ans-prod-hadoop.md
@@ -1,5 +1,4 @@
 ---
-layout: event
 title:  "REX : 2 ans de prod d'un cluster Hadoop"
 address: "INSA Lyon, Amphi Télécom, 6 Avenue des Arts, Villeurbanne"
 address-link: "https://goo.gl/maps/jJfcfezozUTjGz3J6"

--- a/_posts/2019-11-28-pourquoi-gradle.md
+++ b/_posts/2019-11-28-pourquoi-gradle.md
@@ -1,5 +1,4 @@
 ---
-layout: event
 title:  "Pourquoi Gradle ?"
 address: "INSA Lyon, Amphi Télécom, 6 Avenue des Arts, Villeurbanne"
 address-link: "https://goo.gl/maps/jJfcfezozUTjGz3J6"

--- a/_posts/2019-12-16-quoi-de-neuf-rabbitmq.md
+++ b/_posts/2019-12-16-quoi-de-neuf-rabbitmq.md
@@ -1,5 +1,4 @@
 ---
-layout: event
 title:  "Quoi de neuf, RabbitMQ ?"
 address: "INSA Lyon, Amphi Télécom, 6 Avenue des Arts, Villeurbanne"
 address-link: "https://goo.gl/maps/jJfcfezozUTjGz3J6"


### PR DESCRIPTION
Hide signup link on past events or events without Meetup event ID. Replace the signup button at the top of event page by a placeholder text.

Set default layout for posts to "event".

![Capture d’écran de 2019-11-30 18-20-47](https://user-images.githubusercontent.com/5288506/69903765-4153e880-139e-11ea-9fe4-974f34054ff8.png)
