### PR TITLE
fix #27: Fix bad footer behavior on mobile

### DIFF
--- a/_includes/small_footer.html
+++ b/_includes/small_footer.html
@@ -1,0 +1,3 @@
+<footer class="footer font-small bg-light">
+    {% include copyright.html %}
+</footer>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,7 +5,7 @@ layout: default
 {{ content }}
 
 <!-- Footer -->
-<footer class="page-footer font-small pt-4 bg-light shadow">
+<footer class="footer font-small pt-4 bg-light">
 
     <div class="container">
         <div class="row">

--- a/index.html
+++ b/index.html
@@ -48,9 +48,7 @@ layout: default
     {% include partners_logos.html logo-class="logo" %}
 </div>
 
-<footer class="page-footer font-small pt-4 bg-light shadow">
-    {% include copyright.html %}
-</footer>
+{% include small_footer.html %}
 
 <script>
     var elements = document.querySelectorAll('[future-date]');

--- a/sponsors.html
+++ b/sponsors.html
@@ -25,6 +25,4 @@ layout: default
 
 </div>
 
-<footer class="page-footer font-small pt-4 bg-light shadow fixed-bottom">
-    {% include copyright.html %}
-</footer>
+{% include small_footer.html %}


### PR DESCRIPTION
Remove footer shadow and fixation to bottom, to avoid footer to overlap content on mobile.